### PR TITLE
added org support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 # https://github.com/settings/tokens
 GITHUB_TOKEN=your_github_personal_access_token
 GITHUB_OWNER=your_github_user
+GITHUB_OWNER_TYPE=org # defaults to user
 ALLOWED_REPOS=owner/name,foo/bar #Keep empty to allow all repos
 
 # Server Configuration

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ npx -y @smithery/cli install taylor-lindores-reeves/mcp-github-projects --client
    ```
    GITHUB_TOKEN=your_github_personal_access_token
    GITHUB_OWNER=your_github_username
+   GITHUB_OWNER_TYPE=org
+   ALLOWED_REPOS=owner/repo,another/repo
    ```
 
 4. Build the server:
@@ -68,6 +70,7 @@ npx -y @smithery/cli install taylor-lindores-reeves/mcp-github-projects --client
       "env": {
         "GITHUB_TOKEN": "your_github_personal_access_token",
         "GITHUB_OWNER": "your_github_username_or_org",
+        "GITHUB_OWNER_TYPE": "org",
         "ALLOWED_REPOS": "owner/repo,another/repo"
       }
     }
@@ -79,7 +82,19 @@ npx -y @smithery/cli install taylor-lindores-reeves/mcp-github-projects --client
 
 - `GITHUB_TOKEN`: GitHub Personal Access Token with appropriate permissions
 - `GITHUB_OWNER`: GitHub username or organization name
+- `GITHUB_OWNER_TYPE`: (Optional) Set to `user` (default) or `org`. Controls whether project listing and management is done for a user or an organization. Set to `org` if your projects live in a GitHub organization.
 - `ALLOWED_REPOS`: (Optional) Comma-separated list of allowed repository slugs (e.g. `owner/repo,another/repo`). All write operations (creating/updating issues, adding items to projects, etc.) are restricted to these repositories. If not set or empty, all repositories are allowed by default.
+
+**Example:**
+
+```
+GITHUB_TOKEN=your_github_personal_access_token
+GITHUB_OWNER=the-troops
+GITHUB_OWNER_TYPE=org
+ALLOWED_REPOS=the-troops/sms-troopers,manuelbiermann/convo-run
+```
+
+If you try to perform a write operation on a repository not in this list, the server will throw an error and block the action.
 
 ## GitHub Token Permissions
 

--- a/src/graphql/projects/index.ts
+++ b/src/graphql/projects/index.ts
@@ -22,6 +22,8 @@ import updateProjectV2Mutation from "../projects/updateProjectV2.graphql";
 import updateProjectV2FieldMutation from "../projects/updateProjectV2Field.graphql";
 import updateProjectV2ItemPositionMutation from "../projects/updateProjectV2ItemPosition.graphql";
 import updateProjectV2StatusUpdateMutation from "../projects/updateProjectV2StatusUpdate.graphql";
+import listUserProjectsQuery from "./listUserProjects.graphql";
+import listOrgProjectsQuery from "./listOrgProjects.graphql";
 
 // Export operations
 export const getProject = getProjectQuery;
@@ -37,7 +39,7 @@ export const deleteProjectV2 = deleteProjectV2Mutation;
 export const copyProjectV2 = copyProjectV2Mutation;
 export const addProjectV2DraftIssue = addProjectV2DraftIssueMutation;
 export const convertProjectV2DraftIssueToIssue =
-	convertProjectV2DraftIssueToIssueMutation;
+  convertProjectV2DraftIssueToIssueMutation;
 export const updateProjectV2ItemPosition = updateProjectV2ItemPositionMutation;
 export const deleteProjectV2Item = deleteProjectV2ItemMutation;
 export const createProjectV2Field = createProjectV2FieldMutation;
@@ -47,6 +49,8 @@ export const updateProjectV2StatusUpdate = updateProjectV2StatusUpdateMutation;
 export const archiveProjectV2Item = archiveProjectV2ItemMutation;
 export const unarchiveProjectV2Item = unarchiveProjectV2ItemMutation;
 export const clearProjectV2ItemFieldValue =
-	clearProjectV2ItemFieldValueMutation;
+  clearProjectV2ItemFieldValueMutation;
 export const markProjectV2AsTemplate = markProjectV2AsTemplateMutation;
 export const unmarkProjectV2AsTemplate = unmarkProjectV2AsTemplateMutation;
+export const listUserProjects = listUserProjectsQuery;
+export const listOrgProjects = listOrgProjectsQuery;

--- a/src/graphql/projects/listOrgProjects.graphql
+++ b/src/graphql/projects/listOrgProjects.graphql
@@ -1,0 +1,20 @@
+query ListOrgProjects($login: String!, $first: Int, $after: String) {
+  organization(login: $login) {
+    projectsV2(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        title
+        shortDescription
+        url
+        number
+        createdAt
+        updatedAt
+        closed
+      }
+    }
+  }
+}

--- a/src/graphql/projects/listProjects.graphql
+++ b/src/graphql/projects/listProjects.graphql
@@ -1,5 +1,28 @@
-query ListProjects($login: String!, $first: Int, $after: String) {
+# User-based query
+query ListUserProjects($login: String!, $first: Int, $after: String) {
   user(login: $login) {
+    projectsV2(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        title
+        shortDescription
+        url
+        number
+        createdAt
+        updatedAt
+        closed
+      }
+    }
+  }
+}
+
+# Organization-based query
+query ListOrgProjects($login: String!, $first: Int, $after: String) {
+  organization(login: $login) {
     projectsV2(first: $first, after: $after) {
       pageInfo {
         hasNextPage

--- a/src/graphql/projects/listUserProjects.graphql
+++ b/src/graphql/projects/listUserProjects.graphql
@@ -1,0 +1,20 @@
+query ListUserProjects($login: String!, $first: Int, $after: String) {
+  user(login: $login) {
+    projectsV2(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        id
+        title
+        shortDescription
+        url
+        number
+        createdAt
+        updatedAt
+        closed
+      }
+    }
+  }
+}

--- a/src/operations/issues.ts
+++ b/src/operations/issues.ts
@@ -97,6 +97,13 @@ function isRepoAllowedSlug(slug: string) {
   );
 }
 
+function getRepoSlug(owner: string, repo: string) {
+  // If repo already contains a slash, assume it's a full slug
+  return repo.includes("/")
+    ? repo.toLowerCase()
+    : `${owner}/${repo}`.toLowerCase();
+}
+
 export class IssueOperations {
   private client: GitHubClient;
   private owner: string;
@@ -209,7 +216,7 @@ export class IssueOperations {
    */
   async createIssue(params: CreateIssueParams) {
     const { repo, title, body, assignees, milestone, labels } = params;
-    const repoSlug = `${this.owner}/${repo}`;
+    const repoSlug = getRepoSlug(this.owner, repo);
     if (!isRepoAllowedSlug(repoSlug)) {
       throw new Error(
         `Repository ${repoSlug} is not allowed by ALLOWED_REPOS, which is ${ALLOWED_REPOS.join(
@@ -265,9 +272,13 @@ export class IssueOperations {
       labels,
       milestone,
     } = params;
-    const repoSlug = `${this.owner}/${repo}`;
+    const repoSlug = getRepoSlug(this.owner, repo);
     if (!isRepoAllowedSlug(repoSlug)) {
-      throw new Error(`Repository ${repoSlug} is not allowed by ALLOWED_REPOS`);
+      throw new Error(
+        `Repository ${repoSlug} is not allowed by ALLOWED_REPOS, which is ${ALLOWED_REPOS.join(
+          ", "
+        )}`
+      );
     }
     const path = `/repos/${this.owner}/${repo}/issues/${issueNumber}`;
 

--- a/src/types/github-api-types.ts
+++ b/src/types/github-api-types.ts
@@ -31636,14 +31636,23 @@ export type GetProjectItemsQuery = { node: { items: { pageInfo: { hasNextPage: b
           & { __typename: 'Issue' | 'PullRequest' }
         ) | null } | null> | null } } | null };
 
-export type ListProjectsQueryVariables = Exact<{
+export type ListOrgProjectsQueryVariables = Exact<{
   login: Scalars['String']['input'];
   first: InputMaybe<Scalars['Int']['input']>;
   after: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type ListProjectsQuery = { user: { projectsV2: { pageInfo: { hasNextPage: boolean, endCursor: string | null }, nodes: Array<{ id: string, title: string, shortDescription: string | null, url: string, number: number, createdAt: string, updatedAt: string, closed: boolean } | null> | null } } | null };
+export type ListOrgProjectsQuery = { organization: { projectsV2: { pageInfo: { hasNextPage: boolean, endCursor: string | null }, nodes: Array<{ id: string, title: string, shortDescription: string | null, url: string, number: number, createdAt: string, updatedAt: string, closed: boolean } | null> | null } } | null };
+
+export type ListUserProjectsQueryVariables = Exact<{
+  login: Scalars['String']['input'];
+  first: InputMaybe<Scalars['Int']['input']>;
+  after: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type ListUserProjectsQuery = { user: { projectsV2: { pageInfo: { hasNextPage: boolean, endCursor: string | null }, nodes: Array<{ id: string, title: string, shortDescription: string | null, url: string, number: number, createdAt: string, updatedAt: string, closed: boolean } | null> | null } } | null };
 
 export type MarkProjectV2AsTemplateMutationVariables = Exact<{
   input: MarkProjectV2AsTemplateInput;


### PR DESCRIPTION
## Support for Organization Projects and Explicit Owner Type

### What’s Changed

- Added support for listing and managing GitHub Projects for both users and organizations.
- Introduced a new environment variable: `GITHUB_OWNER_TYPE` (`user` or `org`). This controls whether project operations are performed for a user or an organization.
- Updated the code to use the correct GraphQL query for project listing based on the owner type.
- Improved type safety for project listing operations.
- Updated the README to document the new `GITHUB_OWNER_TYPE` variable and provide clear configuration examples.
- Maintained full backward compatibility: if `GITHUB_OWNER_TYPE` is not set, defaults to `user`.

### Why

- GitHub Projects v2 can live under both users and organizations, but the API requires different queries for each.
- The previous implementation only supported user-owned projects or used unreliable heuristics for org detection.
- This change makes org/user support explicit, robust, and easy to configure.

### How to Use

- Set `GITHUB_OWNER_TYPE=org` in your environment if your projects are in a GitHub organization.
- Example:
  ```
  GITHUB_TOKEN=your_github_personal_access_token
  GITHUB_OWNER=the-troops
  GITHUB_OWNER_TYPE=org
  ALLOWED_REPOS=the-troops/sms-troopers,manuelbiermann/convo-run
  ```
